### PR TITLE
Shows the version of NVDA that will be downloaded on each channel.

### DIFF
--- a/addon/globalPlugins/updateChannel.py
+++ b/addon/globalPlugins/updateChannel.py
@@ -15,7 +15,7 @@ try:
 except:
 	updateCheck = None
 import globalVars
-from threading import Thread
+from threading import Thread, Lock
 
 addonHandler.initTranslation()
 originalChannel = None
@@ -43,7 +43,7 @@ channelDescriptions = [
 ]
 
 class UpdateChannelPanel(SettingsPanel):
-	# TRANSLATORS: title for the Update Channel settings category
+# TRANSLATORS: title for the Update Channel settings category
 	title = _("Update channel")
 
 	def makeSettings(self, sizer):
@@ -63,54 +63,66 @@ class UpdateChannelPanel(SettingsPanel):
 			self.channelInfo = helper.addItem(wx.TextCtrl(self, style=wx.TE_RICH|wx.TE_NO_VSCROLL|wx.TE_WORDWRAP|wx.TE_MULTILINE|wx.TE_READONLY, value = "", size=(300,20)))
 			self.channelInfo.Bind(wx.EVT_TEXT, self.onText)
 			self.channelInfo.Disable()
-			# Also, create links to download and view changelog.
+			# Also, create hyperlinks to download and view changelog.
 			self.download = helper.addItem(wx.adv.HyperlinkCtrl(self, style=wx.adv.HL_CONTEXTMENU))
 			self.download.Hide()
 			self.changelog = helper.addItem(wx.adv.HyperlinkCtrl(self, style=wx.adv.HL_CONTEXTMENU, label=_("View changelog")))
 			self.changelog.Hide()
 			self.availableUpdates = {}
 			# It is done in a separate thread so as not to slow down the execution.
-			self.thGetAvailableUpdates = Thread(target=self.getAvailableUpdates)
+			self.lockVersionType = Lock()
+			self.lockAvailableUpdates = Lock()
+			self.flagSaved = False
+			self.flagDiscarded = False
+			self.thGetAvailableUpdates = Thread(target=self.getAvailableUpdates, args=(versionInfo.updateVersionType,))
+			self.thGetAvailableUpdates.setDaemon(True)
 			self.thGetAvailableUpdates.start()
 
-	def getAvailableUpdates(self):
+	def getAvailableUpdates(self, currentChannel):
 		""" Retrieves the information about the version to download for each update channel. """
-		currentChannel = versionInfo.updateVersionType
 		for channel in channels:
 			if channel == "default" or not channel:
 				continue
+			self.lockVersionType.acquire()
+			self.lockAvailableUpdates.acquire()
+			if self.flagSaved or self.flagDiscarded:
+				break
 			try:
 				versionInfo.updateVersionType = channel
 				self.availableUpdates[channel] = updateCheck.checkForUpdate()
 				if not self.availableUpdates[channel]: self.availableUpdates[channel] = 1 # Already updated
 			except:
 				self.availableUpdates[channel] = -1 # An error occurred
-			finally:
+			else:
+				if self.flagSaved or self.flagDiscarded:
+					break
 				# Don't wait for wx.EVT_CHOICE, update selected channel in self.channels now.
 				try:
 					if channel == channels[self.channels.Selection]:
-						self.setUpdateInfo(self.availableUpdates[channel])
-				except RuntimeError: # Occurs when UpdateChannelPanel closes before the thread has finished.
-					try:
-						# updateVersionType has been modified by the thread; if it is interrupted, before terminating it, updateVersionType must receive the correct value.
-						if channels[config.conf.profiles[0]['updateChannel']['channel']] == 'default':
-							versionInfo.updateVersionType = originalChannel
-						else:
-							versionInfo.updateVersionType = channels[config.conf.profiles[0]['updateChannel']['channel']]
-					except KeyError:
-						versionInfo.updateVersionType = originalChannel
-					return
-		versionInfo.updateVersionType = currentChannel
+						self.displayUpdateInfo(self.availableUpdates[channel])
+				except Exception:
+					if self.lockAvailableUpdates.locked(): self.lockAvailableUpdates.release()
+					if self.lockVersionType.locked(): self.lockVersionType.release()
+					raise Exception
+			finally:
+				if self.lockAvailableUpdates.locked(): self.lockAvailableUpdates.release()
+				self.lockVersionType.release()
+		self.lockVersionType.acquire()
+		if not (self.flagSaved and not self.flagDiscarded):
+			versionInfo.updateVersionType = currentChannel
+		self.lockVersionType.release()
 
-	def setUpdateInfo(self, updateVersionInfo):
-		""" Select the appropriate message and put it in the edit box.
-		Also, updates de hiperlinks. """
+	def displayUpdateInfo(self, updateVersionInfo):
+		""" Select the appropriate message and put it in the edit box and updates de hyperlinks. """
 		showLinks = False
 		if channels[self.channels.Selection] == "default":
 			try:
+				self.lockAvailableUpdates.acquire()
 				updateVersionInfo = self.availableUpdates[originalChannel]
 			except KeyError:
 				updateVersionInfo = None
+			finally:
+				self.lockAvailableUpdates.release()
 		if updateVersionInfo:
 			try:
 				channelInfo = updateVersionInfo["version"]
@@ -136,6 +148,8 @@ class UpdateChannelPanel(SettingsPanel):
 			if self.thGetAvailableUpdates.isAlive():
 				# TRANSLATORS: Message displayed when retrieval of update information has not yet been completed.
 				channelInfo = _("searching update info")
+			else:
+				channelInfo = ""
 		if channels[self.channels.Selection] == None:
 			# TRANSLATORS: When disable updates has been selected, the current version information is displayed.
 			channelInfo = _("Current version: %s build %s") % (versionInfo.version, versionInfo.version_build)
@@ -147,10 +161,13 @@ class UpdateChannelPanel(SettingsPanel):
 	def onChoice(self, evt):
 		""" Updates the channel information when the selection is changed. """
 		try:
+			self.lockAvailableUpdates.acquire()
 			updateVersionInfo = self.availableUpdates[channels[self.channels.Selection]]
 		except KeyError:
 			updateVersionInfo  = None
-		self.setUpdateInfo(updateVersionInfo)
+		finally:
+			self.lockAvailableUpdates.release()
+		self.displayUpdateInfo(updateVersionInfo)
 
 	def onText(self, evt):
 		if self.channelInfo.GetValue():
@@ -159,6 +176,7 @@ class UpdateChannelPanel(SettingsPanel):
 			if self.channelInfo.IsEnabled(): self.channelInfo.Disable()
 
 	def onSave(self):
+		self.lockVersionType.acquire()
 		try:
 			# Use normal profile only if possible
 			config.conf.profiles[0]['updateChannel']['channel'] = self.channels.Selection
@@ -180,7 +198,13 @@ class UpdateChannelPanel(SettingsPanel):
 			updateCheck.saveState()
 		except:  # updateCheck module was not imported
 			pass
+		self.flagSaved = True
+		self.lockVersionType.release()
 
+	def onDiscard(self):
+		self.lockVersionType.acquire()
+		self.flagDiscarded = True
+		self.lockVersionType.release()
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def __init__(self):


### PR DESCRIPTION
I thought it would be interesting to know which version will be downloaded on each channel. It turned out a bit more difficult than I thought but here it is.

I have used a read-only edit box to display the information. The problem is that being read-only does not receive the focus by the tab key, it must be sought through the objects navegator. I don't want to use wx.TE_MULTILINE because it cuts the lines and it seems unaesthetic to me, maybe I just have to adjust the size but I'm not good at graphical interfaces.