### PR TITLE
Restore alpha snapshot update channel

### DIFF
--- a/addon/globalPlugins/updateChannel.py
+++ b/addon/globalPlugins/updateChannel.py
@@ -25,13 +25,17 @@ addonHandler.initTranslation()
 originalChannel = None
 confspec = {
 	"channel": "integer(default=0)",
+	"configVersion": "integer(default=1)",
 }
 config.conf.spec["updateChannel"] = confspec
 
 ALPHA_CHANNEL = "snapshot:alpha"
 ALPHA_FALLBACK_VERSION = "alpha-0,00000000"
+CONFIG_VERSION = 2
+LEGACY_DISABLE_UPDATES_CHANNEL_INDEX = 3
+DISABLE_UPDATES_CHANNEL_INDEX = 4
 
-channels = ["default", "stable", "beta", None, ALPHA_CHANNEL]
+channels = ["default", "stable", "beta", ALPHA_CHANNEL, None]
 channelDescriptions = [
 	# TRANSLATORS: default channel option in the combo box
 	_("Default"),
@@ -39,10 +43,10 @@ channelDescriptions = [
 	_("Stable"),
 	# TRANSLATORS: release candidate and beta releases option in the combo box
 	_("Rc and beta"),
-	# TRANSLATORS: disable updates option in the combo box
-	_("Disable updates (not recommended)"),
 	# TRANSLATORS: alpha snapshots option in the combo box
 	_("Alpha (snapshots)"),
+	# TRANSLATORS: disable updates option in the combo box
+	_("Disable updates (not recommended)"),
 ]
 
 
@@ -58,10 +62,21 @@ def getVersionStringFromBuildValues():
 def getConfiguredChannel():
 	try:
 		# Use normal profile only if possible
-		return int(config.conf.profiles[0]["updateChannel"]["channel"])
+		updateChannelConfig = config.conf.profiles[0]["updateChannel"]
 	except Exception:
 		# When using for the first time, read from general configuration
-		return config.conf["updateChannel"]["channel"]
+		updateChannelConfig = config.conf["updateChannel"]
+	configuredChannel = int(updateChannelConfig["channel"])
+	try:
+		configVersion = int(updateChannelConfig["configVersion"])
+	except Exception:
+		configVersion = 1
+	if configVersion < CONFIG_VERSION:
+		if configuredChannel == LEGACY_DISABLE_UPDATES_CHANNEL_INDEX:
+			configuredChannel = DISABLE_UPDATES_CHANNEL_INDEX
+			updateChannelConfig["channel"] = configuredChannel
+		updateChannelConfig["configVersion"] = CONFIG_VERSION
+	return configuredChannel
 
 
 def shouldUseAlphaFallbackVersion():
@@ -270,9 +285,13 @@ class UpdateChannelPanel(SettingsPanel):
 		try:
 			# Use normal profile only if possible
 			config.conf.profiles[0]["updateChannel"]["channel"] = self.channels.Selection
+			config.conf.profiles[0]["updateChannel"]["configVersion"] = CONFIG_VERSION
 		except Exception:
 			# When configuring for the first time, required keys are created in the normal profile
-			config.conf.profiles[0]["updateChannel"] = {"channel": self.channels.Selection}
+			config.conf.profiles[0]["updateChannel"] = {
+				"channel": self.channels.Selection,
+				"configVersion": CONFIG_VERSION,
+			}
 		if self.channels.Selection == 0:
 			buildVersion.updateVersionType = originalChannel
 		else:

--- a/addon/globalPlugins/updateChannel.py
+++ b/addon/globalPlugins/updateChannel.py
@@ -28,7 +28,10 @@ confspec = {
 }
 config.conf.spec["updateChannel"] = confspec
 
-channels = ["default", "stable", "beta", None]
+ALPHA_CHANNEL = "snapshot:alpha"
+ALPHA_FALLBACK_VERSION = "alpha-0,00000000"
+
+channels = ["default", "stable", "beta", None, ALPHA_CHANNEL]
 channelDescriptions = [
 	# TRANSLATORS: default channel option in the combo box
 	_("Default"),
@@ -38,6 +41,8 @@ channelDescriptions = [
 	_("Rc and beta"),
 	# TRANSLATORS: disable updates option in the combo box
 	_("Disable updates (not recommended)"),
+	# TRANSLATORS: alpha snapshots option in the combo box
+	_("Alpha (snapshots)"),
 ]
 
 
@@ -59,6 +64,10 @@ def getConfiguredChannel():
 		return config.conf["updateChannel"]["channel"]
 
 
+def shouldUseAlphaFallbackVersion():
+	return buildVersion.updateVersionType == ALPHA_CHANNEL and not buildVersion.version.startswith("alpha-")
+
+
 def checkForUpdateReplacement(auto=False):
 	# As described in issue #3 when updating from Alpha to stable NV Access's server
 	# offers version 2019.2, rather than whatever is the stable release at the time.
@@ -67,14 +76,20 @@ def checkForUpdateReplacement(auto=False):
 	# We cannot do this when initializing the plugin
 	# as this breaks the process of creating portable copies (see issue #5).
 	ORIG_NVDA_VERSION = buildVersion.version
-	IS_ALPHA = originalChannel == "snapshot:alpha"
+	IS_ALPHA = originalChannel == ALPHA_CHANNEL
 	shouldReplaceVersion = False
+	replacementVersion = None
 	if IS_ALPHA and buildVersion.updateVersionType != originalChannel:
 		shouldReplaceVersion = True
 	if not shouldReplaceVersion and IS_ALPHA and getConfiguredChannel() in {1, 2}:
 		shouldReplaceVersion = True
+	if shouldUseAlphaFallbackVersion():
+		shouldReplaceVersion = True
+		replacementVersion = ALPHA_FALLBACK_VERSION
+	elif shouldReplaceVersion:
+		replacementVersion = getVersionStringFromBuildValues()
 	if shouldReplaceVersion:
-		buildVersion.version = getVersionStringFromBuildValues()
+		buildVersion.version = replacementVersion
 		importlib.reload(versionInfo)
 	try:
 		return updateCheck.checkForUpdate_orig(auto)
@@ -171,7 +186,7 @@ class UpdateChannelPanel(SettingsPanel):
 			importlib.reload(versionInfo)
 		elif self.status == 2:
 			# Workaround for issue 3
-			if originalChannel == "snapshot:alpha" and originalChannel == currentChannel:
+			if originalChannel == ALPHA_CHANNEL and originalChannel == currentChannel:
 				buildVersion.updateVersionType = currentChannel
 				importlib.reload(versionInfo)
 
@@ -301,7 +316,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		global originalChannel
 		originalChannel = buildVersion.updateVersionType
 		index = getConfiguredChannel()
-		if index > len(channels):
+		if index >= len(channels):
 			index = 0
 		if index > 0:
 			buildVersion.updateVersionType = channels[index]

--- a/buildVars.py
+++ b/buildVars.py
@@ -24,7 +24,7 @@ addon_info = AddonInfo(
 	addon_version = "26.3",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=_("""Bug fixes"""),
+	addon_changelog=_("""Restored the alpha snapshots update channel."""),
 	# Author(s)
 	addon_author = "Jose Manuel Delicado <jm.delicado@nvda.es>, Javi Dominguez <fjavids@gmail.com>",
 	# URL for the add-on documentation support

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,8 @@ You can change the NVDA update channel by going to NVDA menu, Preferences, Setti
 * Default: this is the default channel used by your NVDA version. Choosing this option means the same as disabling the add-on.
 * Stable: force update channel to stable. Useful when you want to upgrade to a newer stable version from a beta.
 * Rc and beta: this is the channel for beta releases. You will receive the first beta version once it is released. This channel allows you to update through betas and release candidates.
-* Disable updates (not recommended): this option disables the update channel. If you check for updates an error message will be displayed. Remember that you can disable automatic updates from the General settings category. Use this option only with testing purposes.
 * Alpha (snapshots): choose this option to update to the latest alpha snapshot. Alpha snapshots allow you to test new features, but they are unstable.
+* Disable updates (not recommended): this option disables the update channel. If you check for updates an error message will be displayed. Remember that you can disable automatic updates from the General settings category. Use this option only with testing purposes.
 
 Information about available updates for each channel will be retrieved in the background once the settings panel is opened. Press tab to navigate to a read only edit field, where you can see this information. This information will be dynamically updated when you change the update channel from the combo box. If there is an update available for the selected channel, one or two links will appear next to the edit field:
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ You can change the NVDA update channel by going to NVDA menu, Preferences, Setti
 * Stable: force update channel to stable. Useful when you want to upgrade to a newer stable version from a beta.
 * Rc and beta: this is the channel for beta releases. You will receive the first beta version once it is released. This channel allows you to update through betas and release candidates.
 * Disable updates (not recommended): this option disables the update channel. If you check for updates an error message will be displayed. Remember that you can disable automatic updates from the General settings category. Use this option only with testing purposes.
+* Alpha (snapshots): choose this option to update to the latest alpha snapshot. Alpha snapshots allow you to test new features, but they are unstable.
 
 Information about available updates for each channel will be retrieved in the background once the settings panel is opened. Press tab to navigate to a read only edit field, where you can see this information. This information will be dynamically updated when you change the update channel from the combo box. If there is an update available for the selected channel, one or two links will appear next to the edit field:
 
@@ -19,6 +20,10 @@ Information about available updates for each channel will be retrieved in the ba
 * View changelog: press spacebar on this link to open the What's new document in your web browser. For some channels, this link won't be displayed.
 
 ## Changelog
+
+### Version 26.3
+
+* Restored the alpha snapshots update channel.
 
 ### Version 26.1
 


### PR DESCRIPTION
## Summary
- restore the Alpha snapshots channel as an explicit update mode above Disable updates
- use an alpha-shaped fallback version when checking alpha from stable/beta builds, because the NV Access API returns no alpha update for stable version strings
- migrate the old Disable updates index to the new index so existing disabled configurations stay disabled

## Testing
- python C:\tmp\test_update_channel_modes.py
- python C:\tmp\test_nvda_update_api_modes.py
  - stable: update metadata returned
  - beta: update metadata returned
  - alpha direct from stable version: no update returned
  - alpha fallback: alpha-56053,b9ab7106 -> https://download.nvaccess.org/snapshots/alpha/nvda_snapshot_alpha-56053,b9ab7106.exe
  - disabled: local mode; no update API request expected
- py -V:Astral/CPython3.13.13 -m py_compile addon\\globalPlugins\\updateChannel.py buildVars.py
- python -m ruff check addon\\globalPlugins\\updateChannel.py
- scons
- scons pot
- git diff --check